### PR TITLE
Probability threshold on prediciton

### DIFF
--- a/linesegmentation/detection/lineDetectionUtil.py
+++ b/linesegmentation/detection/lineDetectionUtil.py
@@ -49,6 +49,7 @@ def vertical_runs(img: np.array):
             white_runs[w - 1 - x] += 1
         else:
             black_runs[w - 1 - x] += 1
+
     black_r = np.argmax(black_runs) + 1
     # on pages with a lot of text the staffspaceheigth can be falsified.
     # --> skip the first elements of the array, we expect the staff lines distance to be at least twice the line height

--- a/linesegmentation/detection/lineDetectionUtil.py
+++ b/linesegmentation/detection/lineDetectionUtil.py
@@ -53,8 +53,7 @@ def vertical_runs(img: np.array):
     black_r = np.argmax(black_runs) + 1
     # on pages with a lot of text the staffspaceheigth can be falsified.
     # --> skip the first elements of the array, we expect the staff lines distance to be at least twice the line height
-    white_r = np.argmax(white_runs[black_r * 2:]) + 1 + black_r * 2
-    img = np.transpose(img)
+    white_r = np.argmax(white_runs[black_r * 3:]) + 1 + black_r * 3
     return white_r, black_r
 
 

--- a/linesegmentation/detection/lineDetector.py
+++ b/linesegmentation/detection/lineDetector.py
@@ -1,7 +1,7 @@
 # misc imports
 import os
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, NamedTuple
 import numpy as np
 import math
 # project specific imports
@@ -17,8 +17,7 @@ from collections import defaultdict
 from matplotlib import pyplot as plt
 
 
-@dataclass
-class LineDetectionSettings:
+class LineDetectionSettings(NamedTuple):
     numLine: int = 4
     minLineNum: int = 3
     minLength: int = 6
@@ -34,6 +33,8 @@ class LineDetectionSettings:
     smooth_lines_advdebug: bool = False
     line_fit_distance: float = 0.5
     model: Optional[str] = None
+    model_foreground_threshold = 0.5
+    debug_model = False
     processes: int = 12
 
 
@@ -51,9 +52,10 @@ def get_blackness_of_line(line, image):
 
 def create_data(image: np.ndarray, line_space_height):
     space_height = line_space_height
+    norm_img = image.astype(np.float32) / 255
     if line_space_height == 0:
-        space_height = vertical_runs(binarize(image))[0]
-    image_data = ImageData(height=space_height, image=image.astype(float) / 255)
+        space_height = sum(vertical_runs(binarize(norm_img)))
+    image_data = ImageData(height=space_height, image=norm_img)
     return image_data
 
 

--- a/linesegmentation/pixelclassifier/predictor.py
+++ b/linesegmentation/pixelclassifier/predictor.py
@@ -18,6 +18,8 @@ class PCPredictor:
             [SingleData(binary=i.image, image=i.image, line_height_px= i.height) for i in images]
         )
         for i, pred in enumerate(self.predictor.predict(data)):
-            pred = misc.imresize(pred[0][pred[2].xpad:, pred[2].ypad:], pred[2].original_shape, interp="nearest")
+            # get the probability map for 'foreground' and resize it to the original shape
+            prob = pred.probabilities[pred[2].xpad:, pred[2].ypad:][:, :, 1]
+            pred = misc.imresize(prob, pred[2].original_shape) / 255.0
             yield pred
 


### PR DESCRIPTION
In GitLab by @chwick on Mar 16, 2019, 22:19

Instead of using the label prediction of page segmentation, use the probability map for 'foreground'=='staff lines' instead. Added a parameter as threshold. By default 0.5 so the defaul behavior is not changed.